### PR TITLE
fix(guestbook): degrade gracefully when session lookup fails

### DIFF
--- a/src/routes/_main/guestbook.tsx
+++ b/src/routes/_main/guestbook.tsx
@@ -16,7 +16,7 @@ const getInitialPosts = createServerFn({ method: "GET" }).handler(() => {
 export const Route = createFileRoute("/_main/guestbook")({
   loader: async () => {
     const [authState, initialPosts] = await Promise.all([
-      getSession(),
+      getSession().catch(() => ({ user: null, session: null })),
       getInitialPosts().catch(() => null),
     ]);
     return { authState, initialPosts };


### PR DESCRIPTION
Fixes the failure mode behind #41.

## What happened
A visitor hit `Failed to get session` on /guestbook. The error string isn't in the codebase and the page renders fine today — the shape of the bug is that the route loader awaited `getSession()` unguarded, so any transient auth-backend failure (DB hiccup, env issue at the host) rejected the loader and took the whole page down instead of degrading.

## The fix
One line, matching the existing pattern right next to it:

```ts
const [authState, initialPosts] = await Promise.all([
  getSession().catch(() => ({ user: null, session: null })),
  getInitialPosts().catch(() => null),
]);
```

A failed session lookup now falls back to the signed-out view; the guestbook stays readable and recovers on next load.

@ephraimduncan your call on merge, as with the other PRs.